### PR TITLE
Add docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,42 @@
 # s3_put cookbook
 
-# Requirements
+A library cookbook for the `s3_put` resource, which uploads a file to S3.
 
-# Usage
+## Requirements
 
-# Attributes
+* An AWS account 
+* An S3 bucket
+* AWS credentials
+* `s3:PutObject` permissions for what path(s) you want to upload to on the aforementioned S3 bucket
 
-# Recipes
+## Usage
 
-# Author
+Add a dependency on this cookbook to your cookbook’s metadata or Berksfile.
 
-Author:: EverTrue, Inc. (<eric.herot@evertrue.com>)
+Then, in your recipe, to upload a file:
+
+```ruby
+s3_put 'path/to/my/file.tar.gz' do
+  bucket            'my_bucket'
+  remote_path       '/path/on/s3'
+  access_key_id     'access_key_id'
+  secret_access_key 'secret_access_key'
+  action            :upload
+end
+```
+
+Conversely, to delete one:
+
+```ruby
+s3_put 'path/to/my/file.tar.gz' do
+  bucket            'my_bucket'
+  remote_path       '/path/on/s3'
+  access_key_id     'access_key_id'
+  secret_access_key 'secret_access_key'
+  action            :delete
+end
+```
+
+## Author
+
+Author:: Eric Herot (<eric.herot@evertrue.com>)

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,6 +6,9 @@ description      'Installs/Configures s3_put'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '1.0.2'
 
+source_url 'https://github.com/evertrue/s3_put-cookbook' if respond_to?(:source_url)
+issues_url 'https://github.com/evertrue/s3_put-cookbook/issues' if respond_to?(:issues_url)
+
 supports 'ubuntu', '>= 12.04'
 
 chef_version '>= 12.5'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,8 +1,0 @@
-#
-# Cookbook Name:: s3_put
-# Recipe:: default
-#
-# Copyright (C) 2014 EverTrue, Inc.
-# 
-# All rights reserved - Do Not Redistribute
-#

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -1,3 +1,20 @@
+#
+# Cookbook Name:: s3_put
+# Resource:: s3_put
+#
+# Copyright:: 2014, EverTrue
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 default_action :upload
 
 property :source_file,       String, name_attribute: true


### PR DESCRIPTION
@eherot this documents the current state of the cookbook. Some things I noticed, however:

* The `remote_state` attribute appears to be required regardless of the action
* According to the `aws-s3` docs, the format for storing or deleting an object is:

    ```ruby
    S3Object.store key, open(file_path), bucket
    ```
    * This would suggest the current state of the resource is working in spite of this