### PR TITLE
Drop callback validator from remote_path property

### DIFF
--- a/resources/default.rb
+++ b/resources/default.rb
@@ -2,7 +2,7 @@ default_action :upload
 
 property :source_file,       String, name_attribute: true
 property :bucket,            String, required: true
-property :remote_path,       String, required: true, callbacks: { 'should not be empty' => ->(p) { !p.empty? } }
+property :remote_path,       String, required: true
 property :region,            String, default: 'us-east-1'
 property :access_key_id,     String
 property :secret_access_key, String


### PR DESCRIPTION
An empty string is a valid, if potentially confusing, value for the `remote_path` property, as it corresponds to the root of the S3 bucket.

I’ve set this PRs upstream to #3, since its based on that work. Might make sense to roll this into a v2.0.0, otherwise I’d say it will create another breaking version (not that we’re gonna run out of integers).