### PR TITLE
Drop callback validator from remote_path property

### DIFF
--- a/resources/default.rb
+++ b/resources/default.rb
@@ -19,7 +19,7 @@ default_action :upload
 
 property :source_file,       String, name_attribute: true
 property :bucket,            String, required: true
-property :remote_path,       String, required: true, callbacks: { 'should not be empty' => ->(p) { !p.empty? } }
+property :remote_path,       String, required: true
 property :region,            String, default: 'us-east-1'
 property :access_key_id,     String
 property :secret_access_key, String


### PR DESCRIPTION
An empty string is a valid, if potentially confusing, value for the remote_path property, as it corresponds to the root of the S3 bucket.

A recreation of #4, which merged after #3, and thus did not land in `master`.