### PR TITLE
Add kitchen testing on travis

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -7,6 +7,7 @@ driver:
   security_group_ids:
     - ci-testing
   instance_type: c3.large
+  iam_profile_name: test-kitchen
   interface: public
   tags:
     Env: dev
@@ -29,3 +30,7 @@ suites:
   - name: default
     run_list:
       - recipe[s3_put::default]
+    attributes:
+      test_s3_put:
+        bucket: ops
+        remote_path: chef/test_s3_put

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
   - TEST=cookstyle
   - TEST="foodcritic ."
   - TEST="chef exec rspec"
+  - TEST="kitchen test -d always"
 before_install:
 - chef --version
 - eval "$(chef shell-init bash)"

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,7 @@
 source 'https://supermarket.chef.io'
 
 metadata
+
+group :integration do
+  cookbook 'test_s3_put', path: 'test/integration/cookbooks/test_s3_put'
+end

--- a/test/integration/cookbooks/test_s3_put/Berksfile
+++ b/test/integration/cookbooks/test_s3_put/Berksfile
@@ -1,0 +1,3 @@
+source 'https://supermarket.chef.io'
+
+metadata

--- a/test/integration/cookbooks/test_s3_put/metadata.rb
+++ b/test/integration/cookbooks/test_s3_put/metadata.rb
@@ -1,0 +1,8 @@
+name             'test_s3_put'
+maintainer       'EverTrue, Inc.'
+maintainer_email 'devops@evertrue.com'
+license          'Apache v2.0'
+description      'Tests s3_put'
+version          '0.1.0'
+
+depends 's3_put'

--- a/test/integration/cookbooks/test_s3_put/recipes/default.rb
+++ b/test/integration/cookbooks/test_s3_put/recipes/default.rb
@@ -1,0 +1,15 @@
+file 'test' do
+  content 'This is a test of the s3_put Chef cookbook'
+end
+
+s3_put 'test' do
+  bucket            node['test_s3_put']['bucket']
+  remote_path       node['test_s3_put']['remote_path']
+  action            :upload
+end
+
+s3_put 'delete_test' do
+  bucket            node['test_s3_put']['bucket']
+  remote_path       node['test_s3_put']['remote_path']
+  action            :delete
+end


### PR DESCRIPTION
@eherot this should wire up Travis to do integration tests, but it _does_ require two things:

* An IAM instance profile named `test-kitchen` w/ privileges to upload & delete to `chef/test_s3_put` on a bucket
* A tweak of the `node['test_s3_put']['bucket']` value in `.kitchen.yml` to reflect the actual name of a bucket you’d use for testing this

I ran into some integration/runtime issues w/ the current state of this cookbook, and testing it fully let me catch them. Another PR is incoming with those fixes.