### PR TITLE
Refactor to fix resource

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -9,6 +9,6 @@ version          '1.0.2'
 source_url 'https://github.com/evertrue/s3_put-cookbook' if respond_to?(:source_url)
 issues_url 'https://github.com/evertrue/s3_put-cookbook/issues' if respond_to?(:issues_url)
 
-supports 'ubuntu', '>= 12.04'
+supports 'ubuntu', '>= 14.04'
 
 chef_version '>= 12.5'

--- a/metadata.rb
+++ b/metadata.rb
@@ -11,4 +11,6 @@ issues_url 'https://github.com/evertrue/s3_put-cookbook/issues' if respond_to?(:
 
 supports 'ubuntu', '>= 14.04'
 
-chef_version '>= 12.5'
+chef_version '>= 12.8'
+
+gem 'aws-sdk'

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -24,24 +24,25 @@ property :region,            String, default: 'us-east-1'
 property :access_key_id,     String
 property :secret_access_key, String
 
-chef_gem 'aws-sdk'
-
 require 'aws-sdk'
 
-Aws.config.update(
-  credentials: Aws::Credentials.new(access_key_id, secret_access_key)
-) if access_key_id && secret_access_key
-
-s3 = Aws::S3::Resource.new region: region
-
-remote_path << '/' unless remote_path.end_with? '/'
-
 action :upload do
-  s3.bucket(bucket).object(remote_path + filename).upload_file source_file
+  s3_object.upload_file source_file
 end
 
 action :delete do
-  s3.bucket(bucket).object(remote_path + filename).delete
+  s3_object.delete
+end
+
+def s3_object
+  Aws.config.update(
+    credentials: Aws::Credentials.new(access_key_id, secret_access_key)
+  ) if access_key_id && secret_access_key
+
+  s3 = Aws::S3::Resource.new region: region
+
+  remote_path << '/' unless remote_path.end_with? '/'
+  s3.bucket(bucket).object remote_path + filename
 end
 
 private


### PR DESCRIPTION
This looks like a lot of changes, but really, is two things:

* Fix the scope issue of trying to use properties (e.g., `access_key_id`) outside of the action blocks, by adding a public method, `s3_object`
* Switch from `chef_gem` at compile time to including a `gem` in metadata (new in Chef 12.8, see [the docs on metadata settings](https://docs.chef.io/config_rb_metadata.html#settings) for details)

Along the way, we DRY up the resource significantly, which is a nice win.